### PR TITLE
fix: Resolve concurrency bug during dereferencing

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -15,7 +15,6 @@ const OPERATIONS = ['publish', 'subscribe'];
 const SPECIAL_SECURITY_TYPES = ['oauth2', 'openIdConnect'];
 const PARSERS = {};
 const xParserCircle = 'x-parser-circular';
-const refParser = new $RefParser;
 
 /**
  * @module @asyncapi/parser
@@ -79,7 +78,8 @@ async function parse(asyncapiYAMLorJSON, options = {}) {
     //because of Ajv lacks support for circular refs, parser should not resolve them before Ajv validation and first needs to ignore them and leave circular $refs to successfully validate the document
     //this is done pair to advice from Ajv creator https://github.com/ajv-validator/ajv/issues/1122#issuecomment-559378449
     //later we perform full dereference of circular refs if they occure
-    await dereference(parsedJSON, initialFormat, asyncapiYAMLorJSON, { ...options, dereference: { circular: 'ignore' } });
+    const refParser = new $RefParser;
+    await dereference(refParser, parsedJSON, initialFormat, asyncapiYAMLorJSON, { ...options, dereference: { circular: 'ignore' } });
 
     const ajv = new Ajv({
       jsonPointers: true,
@@ -136,7 +136,7 @@ function parseFromUrl(url, fetchOptions, options) {
   });
 }
 
-async function dereference(parsedJSON, initialFormat, asyncapiYAMLorJSON, options) {
+async function dereference(refParser, parsedJSON, initialFormat, asyncapiYAMLorJSON, options) {
   try {
     return await refParser.dereference(options.path, parsedJSON, {
       continueOnError: true,


### PR DESCRIPTION
**Description**
By reusing the same refParser instance for all calls of the parse-function, it can come to concurrency issues if two parse-calls are executed at the same time (i.e. inside a Promise.all() call). This PR resolves the issue by creating a new json-schema-ref-parser for each call of the parse function.
